### PR TITLE
Custom music search directories added.

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,6 @@
-use std::{ fmt, fs, path::PathBuf };
+use std::{ fmt, fs, path::PathBuf, string };
 use chrono::{ DateTime, Local };
+use id3::Error;
 use pretty_date::pretty_date_formatter::PrettyDateFormatter;
 use super::{ app::Mp3File, tag::SongTags };
 
@@ -18,10 +19,32 @@ impl fmt::Display for Source {
   }
 }
 
+fn read_lines(filename: &str) -> Vec<String> {
+    let mut result = Vec::new();
+
+    let mut file_result = fs::read_to_string(filename);
+    
+    match file_result {
+      Ok(x) => {
+        for line in x.lines() {
+          result.push(line.to_string())
+        }
+      }
+      Err(e) => {
+        println!("Error while trying to open user directories file: {}", e);
+      }
+    }
+      
+    return result;
+}
+
+const DEFAULT_USER_DIRS_FILE_POSTFIX: &str = "/.tagchr/directories.txt";
+
 pub struct State {
   pub running: bool,
   pub search: String,
   files: Vec<Mp3File>,
+  pub directories: Vec<std::path::PathBuf>,
   pub shown_indexes: Vec<usize>,
 }
 
@@ -31,11 +54,59 @@ impl State {
       running: true,
       search: "".into(),
       files: vec![],
+      directories: vec![],
       shown_indexes: vec![],
     };
-    dirs::download_dir().map(|dir| new.scan_mp3_files(dir, Source::Downloads));
-    dirs::audio_dir().map(|dir| new.scan_mp3_files(dir, Source::Music));
+
+    let DEFAULT_USER_DIRS_FILE_PREFIX: &str = match dirs::home_dir() {
+        Some(mut x) => { 
+          &(x.to_str().unwrap_or("~").to_owned())
+        },
+        None => {"~"}
+    };
+
+    let DEFAULT_USER_DIRS_FILE = (DEFAULT_USER_DIRS_FILE_PREFIX).to_string() + DEFAULT_USER_DIRS_FILE_POSTFIX;
+
+    // println!("{}", DEFAULT_USER_DIRS_FILE);
+
+    let user_dirs: Vec<std::path::PathBuf> = read_lines(&DEFAULT_USER_DIRS_FILE).iter().map(
+      |s| {
+        let mut p = std::path::PathBuf::new();
+        p.push(s);
+        // p.canonicalize();
+        return p;
+      }
+    ).collect();
+
+    for dir in user_dirs {
+      new.directories.push(dir);
+    }
+
+    // match dirs::download_dir() {
+    //     Some(x) => {new.directories.push(x);}
+    //     None => {}
+    // }
+    // match dirs::audio_dir() {
+    //     Some(x) => {new.directories.push(x);}
+    //     None => {}
+    // }
+    
+    let dirs = new.directories.clone();
+    for dir in dirs {
+      let canon_dir = dir.canonicalize();
+      match canon_dir {
+        Ok(value) => {  
+          // print!("{:?}", value.to_str());
+          new.scan_mp3_files(value, Source::Downloads)
+        }
+        Err(e) => {
+          println!("Cannot canonicalize path {:?}", dir.to_str());
+        }
+      }
+    }
+    
     new.search_mp3_files(new.search.clone());
+    
     new
   }
   pub fn get_file(&self, i: usize) -> &Mp3File {
@@ -44,8 +115,8 @@ impl State {
   pub fn get_file_mut(&mut self, i: usize) -> &mut Mp3File {
     &mut self.files[i]
   }
-  fn scan_mp3_files(&mut self, path: PathBuf, source: Source) {
-    if let Ok(entries) = fs::read_dir(path) {
+  fn scan_mp3_files(&mut self, path_input: PathBuf, source: Source) {
+    if let Ok(entries) = fs::read_dir(path_input) {
       let mut entries = entries.filter_map(Result::ok).collect::<Vec<_>>();
       entries.sort_by(|a, b|
         b.metadata().unwrap().modified().unwrap().cmp(&a.metadata().unwrap().modified().unwrap())

--- a/src/app/tag.rs
+++ b/src/app/tag.rs
@@ -95,7 +95,7 @@ pub struct SongTags {
 
 impl SongTags {
   pub fn new(song_path: String) -> Self {
-    let tag = Tag::read_from_path(song_path.clone()).unwrap();
+    let tag = Tag::read_from_path(song_path.clone()).expect(&song_path);
     Self {
       song_path,
       title: EditableTag(Editable::new(tag.title().map(|n| n.into()))),

--- a/src/ui/screens/home/screen.rs
+++ b/src/ui/screens/home/screen.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Sender;
 
 use crate::{
-  app::{ app::{ App, Command }, state::State, tag::SongTags },
+  app::{ app::{ App, Command }, state::{ State, Source }, tag::SongTags },
   info::{ PROJECT_DESC, PROJECT_NAME },
   ui::{
     block::BlockTrait,
@@ -361,7 +361,25 @@ impl StateDependentWidget for HomeScreen {
                       ])
                     )
                   ),
-                  Cell::new(f.source.to_string().green().italic()),
+                  //  ...(some path)
+                  // |              | -> 16 - current max length of string in section (may change with different layout. idk how to compute)
+                  //     (some path)  -> 13 
+                  Cell::new(
+                    match f.source {
+                      Source::Custom => {   
+                        (
+                          match (f.path.rfind("/")) {
+                            Some(x) => { ("..".to_string() + &f.path[x-14..x]) }
+                            None => { ("..".to_string() + &f.path[f.path.len()-1-14..f.path.len()-1]) }
+                          }
+                        )
+                        .to_string().green().italic()
+                      },
+                      _ => {
+                        f.source.to_string().blue().italic()
+                      },
+                    }
+                  ),
                   Cell::new(f.modified_date.clone().dark_gray())
                 ]
               )


### PR DESCRIPTION
Custom music search directories added.
They are loaded line by line from `directories.txt` file located at `$HOME/.tagchr/` folder, where `$HOME` is provided by rust's `dirs::home_dir()`.

When displaying music's path, if it is loaded from built-in path folder, it has short name and is printed blue. If it is loaded from path provided by user, it shows full name (at least last characters that fit into section) and is printed green.

![изображение](https://github.com/user-attachments/assets/d6aec135-3a16-401d-9fc1-2a2c5f264121)


TODO: automatically create that folder & empty file if they do not exists.

TODO: detect if track was already loaded to not load one track several times.